### PR TITLE
Fixthedocs

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -16,3 +16,4 @@ python:
   
 sphinx:
   builder: html
+  configuration: doc/source/conf.py

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -11,7 +11,8 @@ python:
   system_packages: false
   install:
     - requirements: doc/requirements.txt
+    - method: pip
+      path: .
   
 sphinx:
   builder: html
-  configuration: doc/conf.py

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,0 +1,17 @@
+# Read the Docs configuration file
+# This schema uses https://github.com/23andMe/Yamale
+# for the validation.
+# Default values are indicated with a comment (``Default: ...``).
+# Some values are default to the project config (settings from the web panel).
+
+# The version of the spec to be use
+version: 2
+python:
+  version: 3.6
+  system_packages: false
+  install:
+    - requirements: doc/requirements.txt
+  
+sphinx:
+  builder: html
+  configuration: doc/conf.py


### PR DESCRIPTION
Needed to add some additional configuration files to get ReadTheDocs to stop failing the build when it couldn't build the C components of lxml.